### PR TITLE
Dont duplicate `import Vue`

### DIFF
--- a/server/src/modes/typescriptMode.ts
+++ b/server/src/modes/typescriptMode.ts
@@ -52,14 +52,17 @@ function modifyVueSource(sourceFile: ts.SourceFile): void {
   const exportDefaultObject = find(sourceFile.statements, st => st.kind === ts.SyntaxKind.ExportAssignment &&
     (st as ts.ExportAssignment).expression.kind === ts.SyntaxKind.ObjectLiteralExpression);
   if (exportDefaultObject) {
-    // 1. add `import Vue from './vue'
-    //    (the span of the inserted statement must be (0,0) to avoid overlapping existing statements)
-    const setZeroPos = getWrapperRangeSetter({ pos: 0, end: 0 });
-    const vueImport = setZeroPos(ts.createImportDeclaration(undefined,
-      undefined,
-      setZeroPos(ts.createImportClause(ts.createIdentifier('Vue'), undefined)),
-      setZeroPos(ts.createLiteral('vue'))));
-    sourceFile.statements.unshift(vueImport);
+    const isVueAlreadyImported = find(sourceFile.statements, st => isImportOfName(st, 'Vue'));
+    if (!isVueAlreadyImported) {
+      // 1. add `import Vue from 'vue'
+      //    (the span of the inserted statement must be (0,0) to avoid overlapping existing statements)
+      const setZeroPos = getWrapperRangeSetter({ pos: 0, end: 0 });
+      const vueImport = setZeroPos(ts.createImportDeclaration(undefined,
+        undefined,
+        setZeroPos(ts.createImportClause(ts.createIdentifier('Vue'), undefined)),
+        setZeroPos(ts.createLiteral('vue'))));
+      sourceFile.statements.unshift(vueImport);
+    }
 
     // 2. find the export default and wrap it in `new Vue(...)` if it exists and is an object literal
     //    (the span of the wrapping construct call and *all* its members must be the same as the object literal it wraps)
@@ -74,4 +77,39 @@ function modifyVueSource(sourceFile: ts.SourceFile): void {
 /** Create a function that calls setTextRange on synthetic wrapper nodes that need a valid range */
 function getWrapperRangeSetter(wrapped: ts.TextRange): <T extends ts.TextRange>(wrapperNode: T) => T {
   return <T extends ts.TextRange>(wrapperNode: T) => ts.setTextRange(wrapperNode, wrapped);
+}
+
+function isImportOfName(statement: ts.Statement, name: string): boolean {
+    if (statement.kind === ts.SyntaxKind.ImportDeclaration) {
+      const importDecl = statement as ts.ImportDeclaration;
+      // import (incomplete statement)
+      if (!importDecl.importClause) {
+        return false;
+      }
+      // import Vue from ...
+      if (importDecl.importClause.name && importDecl.importClause.name.text === 'Vue') {
+        return true;
+      }
+      if (!importDecl.importClause.namedBindings) {
+        return false;
+      }
+      // import { Vue } from ...
+      if (importDecl.importClause.namedBindings.kind === ts.SyntaxKind.NamedImports) {
+        const namedImports = importDecl.importClause.namedBindings as ts.NamedImports;
+        if(namedImports.elements && namedImports.elements.some(spec => spec.name.text === "Vue")) {
+          return true;
+        }
+      }
+      // import * as Vue from ...
+      if (importDecl.importClause.namedBindings.kind === ts.SyntaxKind.NamespaceImport) {
+        const namespaceImport = importDecl.importClause.namedBindings as ts.NamespaceImport;
+        return namespaceImport.name && namespaceImport.name.text === "Vue";
+      }
+    }
+    // import Vue (incomplete statement)
+    if (statement.kind === ts.SyntaxKind.ImportEqualsDeclaration) {
+      const importEqDecl = statement as ts.ImportEqualsDeclaration;
+      return importEqDecl.name && importEqDecl.name.text === "Vue";
+    }
+    return false;
 }

--- a/server/src/modes/typescriptMode.ts
+++ b/server/src/modes/typescriptMode.ts
@@ -87,7 +87,7 @@ function isImportOfName(statement: ts.Statement, name: string): boolean {
         return false;
       }
       // import Vue from ...
-      if (importDecl.importClause.name && importDecl.importClause.name.text === 'Vue') {
+      if (importDecl.importClause.name && importDecl.importClause.name.text === name) {
         return true;
       }
       if (!importDecl.importClause.namedBindings) {
@@ -96,20 +96,20 @@ function isImportOfName(statement: ts.Statement, name: string): boolean {
       // import { Vue } from ...
       if (importDecl.importClause.namedBindings.kind === ts.SyntaxKind.NamedImports) {
         const namedImports = importDecl.importClause.namedBindings as ts.NamedImports;
-        if(namedImports.elements && namedImports.elements.some(spec => spec.name.text === "Vue")) {
+        if(namedImports.elements && namedImports.elements.some(spec => spec.name.text === name)) {
           return true;
         }
       }
       // import * as Vue from ...
       if (importDecl.importClause.namedBindings.kind === ts.SyntaxKind.NamespaceImport) {
         const namespaceImport = importDecl.importClause.namedBindings as ts.NamespaceImport;
-        return namespaceImport.name && namespaceImport.name.text === "Vue";
+        return namespaceImport.name && namespaceImport.name.text === name;
       }
     }
     // import Vue (incomplete statement)
     if (statement.kind === ts.SyntaxKind.ImportEqualsDeclaration) {
       const importEqDecl = statement as ts.ImportEqualsDeclaration;
-      return importEqDecl.name && importEqDecl.name.text === "Vue";
+      return importEqDecl.name && importEqDecl.name.text === name;
     }
     return false;
 }


### PR DESCRIPTION
Don't import `import Vue from 'vue'` if user already imports Vue themselves (perhaps even from somewhere else)

Fixes #128 
