### PR TITLE
Add vue-template-compiler to extension manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "engines": {
     "vscode": "^1.8.0"
   },
+  "dependencies": {
+    "vue-template-compiler": "2.2.1"
+  },
   "activationEvents": [
     "onLanguage:vue"
   ],


### PR DESCRIPTION
After consulting with @mjbvz, I think this is the fix for the `vue-template-compiler` bugs linked from #136. Unfortunately, I'm not sure how to make a clean install to test the change.