### PR TITLE
Exclude node_modules in module resolution

### DIFF
--- a/server/src/modes/javascriptMode.ts
+++ b/server/src/modes/javascriptMode.ts
@@ -54,7 +54,9 @@ export function getJavascriptMode(documentRegions: LanguageModelCache<HTMLDocume
   (ts as any).updateLanguageServiceSourceFile = updateLanguageServiceSourceFile;
   const configFilename = ts.findConfigFile(workspacePath, ts.sys.fileExists, 'tsconfig.json') ||
     ts.findConfigFile(workspacePath, ts.sys.fileExists, 'jsconfig.json');
-  const configJson = configFilename && ts.readConfigFile(configFilename, ts.sys.readFile).config || {};
+  const configJson = configFilename && ts.readConfigFile(configFilename, ts.sys.readFile).config || {
+    exclude: ['node_modules']
+  };
   const parsedConfig = ts.parseJsonConfigFileContent(configJson,
     ts.sys,
     workspacePath,


### PR DESCRIPTION
/cc @sandersn 

For #131 and alike, this seems to happen when a project is large.

In one of my project I was able to repro it, and while debugging I found:

https://github.com/octref/vetur/blob/master/server/src/modes/javascriptMode.ts#L50-L67
```ts
  const { createLanguageServiceSourceFile, updateLanguageServiceSourceFile } = createUpdater();
  (ts as any).createLanguageServiceSourceFile = createLanguageServiceSourceFile;
  (ts as any).updateLanguageServiceSourceFile = updateLanguageServiceSourceFile;
  const configFilename = ts.findConfigFile(workspacePath, ts.sys.fileExists, 'tsconfig.json') ||
    ts.findConfigFile(workspacePath, ts.sys.fileExists, 'jsconfig.json');
  const configJson = configFilename && ts.readConfigFile(configFilename, ts.sys.readFile).config || {};
  const parsedConfig = ts.parseJsonConfigFileContent(configJson,
    ts.sys,
    workspacePath,
    compilerOptions,
    configFilename,
    undefined,
    [{ extension: 'vue', isMixedContent: true }]);

  // This files is an array of over 6k items with all js/ts/vue files in current workspace, including those in node_modules
  const files = parsedConfig.fileNames; 

  compilerOptions = parsedConfig.options;
  compilerOptions.allowNonTsExtensions = true;
```

Then later in here:

https://github.com/octref/vetur/blob/master/server/src/modes/javascriptMode.ts#L89-L109
```ts

    resolveModuleNames(moduleNames: string[], containingFile: string): ts.ResolvedModule[] {
      // This is run 6k times, one time for each file
      return moduleNames.map(name => {
        if (path.isAbsolute(name) || !isVue(name)) {
          return ts.resolveModuleName(name, containingFile, compilerOptions, ts.sys).resolvedModule;
        }
        else {
          const uri = Uri.file(path.join(path.dirname(containingFile), name));
          const resolvedFileName = uri.fsPath;
          if (ts.sys.fileExists(resolvedFileName)) {
            const doc = docs.get(resolvedFileName) ||
              jsDocuments.get(TextDocument.create(uri.toString(), 'vue', 0, ts.sys.readFile(resolvedFileName)));
            return {
              resolvedFileName,
              extension: doc.languageId === 'typescript' ? ts.Extension.Ts : ts.Extension.Js,
            };
          }
        }
      });
    },
```

This function is called for each files. So for the whole worksapce it's called 6k times, one time for each js/ts/vue file, and then for each file TS was resolving all modules in them...

I don't know if this PR is the right approach, but it seems to solve the problem.

@sandersn 
Meanwhile in https://github.com/octref/vetur/issues/136#issuecomment-296257118 you said
> I think there may be some tsconfig settings to limit how deeply the compiler follows module resolution inside `node_modules`.

Do you mean `maxNodeModuleJsDepth`? That might help solving this issue, but how is the depth calculated?