### PR TITLE
Fixed link to contributing guidelines' file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [#188](https://github.com/octref/vetur/issues/188).
 
 ## Contribution
 
-See [CONTRIBUTING.md](https://github.com/octref/vetur/blob/master/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/octref/vetur/blob/master/.github/CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
This is just a fix.

The link was pointing to "https://github.com/octref/vetur/blob/master/CONTRIBUTING.md" instead of "https://github.com/octref/vetur/blob/master/.github/CONTRIBUTING.md". 