### PR TITLE
Remove pre publish hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "sync": "npm run sync:server || npm run sync:client",
     "test:server": "cd server && npm run compile && npm test",
     "test": "npm run lint && npm run test:server",
-    "vscode:prepublish": "npm test && npm run sync",
     "doc": "bash ./build/update-docs.sh"
   },
   "repository": {


### PR DESCRIPTION
The thing is `vsce publish` could fail (or sometimes I'd abort it if I realize I forgot something when publishing). In that case I don't want to run `sync` again, especially for `npm publish`.
I'm ok with running two commands each time

```bash
yarn sync
vsce publish
```